### PR TITLE
Fixes the causes for warnings

### DIFF
--- a/src/generate.ml4
+++ b/src/generate.ml4
@@ -4,21 +4,14 @@
 open Format
 open Term
 open EConstr
-open Coqlib
-open Tacmach
-open Tacticals
-open Tactics
 open Pp
 open Flags
 
 open Nameops
-open Entries
 open Constrexpr
 open Constrexpr_ops
-open Topconstr
 open Printing
 open Ltac_plugin
-open Tacinterp
 
 DECLARE PLUGIN "containers_plugin"
 
@@ -308,8 +301,6 @@ let load_tactic_args s lids =
        (Loc.tag @@ Tacexpr.TacCall ( Loc.tag
 				       (Libnames.Ident (dl (Names.Id.of_string s)),
 					args))))
-
-open Tacticals
 
 let property_kind = (Decl_kinds.Global, false, Decl_kinds.Proof Decl_kinds.Property)
 let lemma_kind = (Decl_kinds.Global, false, Decl_kinds.Proof Decl_kinds.Lemma)
@@ -616,7 +607,6 @@ let generate_simple_ot gref =
 (* for recursive datatypes *)
 
 open Declarations
-open Declareops
 
 let print_ind (mind,index) =
   Printf.sprintf "(%s, %d)" (Names.string_of_mind mind) index

--- a/tests/BenchMarks.v
+++ b/tests/BenchMarks.v
@@ -102,8 +102,8 @@ Section ParamSets.
       | S n0 =>
         let z1 := next z in
         let z2 := next z1 in
-        let n1 := Zabs_nat (z1 mod (Z_of_nat size)) in
-        let n2 := Zabs_nat (z2 mod (Z_of_nat size)) in
+        let n1 := Z.abs_nat (z1 mod (Z_of_nat size)) in
+        let n2 := Z.abs_nat (z2 mod (Z_of_nat size)) in
           match nth n1 s {} =?= nth n2 s {} with
             | _ => make_compares (next z2) n0 size s
           end

--- a/theories/MapAVL.v
+++ b/theories/MapAVL.v
@@ -2107,9 +2107,9 @@ Section Encapsulation.
   Section Elt.
     Variable elt elt' elt'': Type.
 
-    Implicit Types m : t elt.
+    Implicit Type m : t elt.
     Implicit Types x y : key.
-    Implicit Types e : elt.
+    Implicit Type e : elt.
 
     Definition empty : t elt := Bst (empty_bst elt).
     Definition is_empty m : bool := Raw.is_empty m.(this).

--- a/theories/MapAVL.v
+++ b/theories/MapAVL.v
@@ -98,7 +98,7 @@ Module MapAVL.
        to be balanced and [|height l - height r| <= 2]. *)
 
     Definition create l x e r :=
-      Node l x e r (Zmax (height l) (height r) + 1).
+      Node l x e r (Z.max (height l) (height r) + 1).
 
     (** [bal l x e r] acts as [create], but performs one step of
        rebalancing if necessary, i.e. assumes [|height l - height r| <= 3]. *)

--- a/theories/MapFacts.v
+++ b/theories/MapFacts.v
@@ -1,5 +1,6 @@
 Require Import Bool Structures.DecidableType Structures.DecidableTypeEx.
-Require Import OrderedType.
+From Containers Require Import OrderedType.
+From Containers Require OrderedTypeEx.
 Module Import K := KeyOrderedType.
 Require Import MapInterface Morphisms.
 Set Implicit Arguments.
@@ -2270,7 +2271,7 @@ End InductiveSpec.
 
 Section AdditionalMorphisms.
   Open Scope map_scope.
-  Require Import OrderedTypeEx.
+  Import OrderedTypeEx.
   (** Additional morphisms, when the value type is Ordered *)
   Context `{HF : @FMapSpecs key Hkey F}.
   Context `{elt_OT : OrderedType elt}.

--- a/theories/MapFacts.v
+++ b/theories/MapFacts.v
@@ -323,9 +323,9 @@ Section WeakFacts.
     Qed.
 
     Variable elt elt' elt'' : Type.
-    Implicit Types m : t elt.
+    Implicit Type m : t elt.
     Implicit Types x y z : key.
-    Implicit Types e : elt.
+    Implicit Type e : elt.
 
     Lemma mem_b : forall m x y, x === y -> mem x m = mem y m.
     Proof.

--- a/theories/MapInterface.v
+++ b/theories/MapInterface.v
@@ -72,7 +72,7 @@ Class FMap `{OrderedType key} := {
   (** Maps are ordered types *)
   FMap_OrderedType :> forall `{OrderedType elt}, OrderedType (dict elt)
 }.
-Implicit Arguments dict [[H] [FMap]].
+Arguments dict key {H FMap}.
 
 (** Map notations (see below) are interpreted in scope [map_scope],
    delimited with key [scope]. We bind it to the type [map] and to

--- a/theories/MapInterface.v
+++ b/theories/MapInterface.v
@@ -75,26 +75,9 @@ Class FMap `{OrderedType key} := {
 Arguments dict key {H FMap}.
 
 (** Map notations (see below) are interpreted in scope [map_scope],
-   delimited with key [scope]. We bind it to the type [map] and to
-   other operations defined in the interface. *)
+   delimited with key [map]. We bind it to the type [dict]. *)
 Delimit Scope map_scope with map.
 Bind Scope map_scope with dict.
-Arguments Scope MapsTo [type_scope _ _ type_scope _ _ map_scope].
-Arguments Scope is_empty [type_scope _ _ type_scope map_scope].
-Arguments Scope mem [type_scope _ _ type_scope _ map_scope].
-Arguments Scope add [type_scope _ _ type_scope _ _ map_scope].
-Arguments Scope find [type_scope _ _ type_scope _ map_scope].
-Arguments Scope remove [type_scope _ _ type_scope _ map_scope].
-Arguments Scope equal [type_scope _ _ type_scope _ map_scope map_scope].
-Arguments Scope map [type_scope _ _ type_scope type_scope _ map_scope].
-Arguments Scope mapi [type_scope _ _ type_scope type_scope _ map_scope].
-Arguments Scope map2 [type_scope _ _ type_scope type_scope
-  type_scope _ map_scope map_scope].
-Arguments Scope fold [type_scope _ _ type_scope type_scope _ map_scope _].
-Arguments Scope cardinal [type_scope _ _ type_scope map_scope].
-Arguments Scope elements [type_scope _ _ type_scope map_scope].
-Arguments Scope insert [type_scope _ _ type_scope _ _ _ map_scope].
-Arguments Scope adjust [type_scope _ _ type_scope _ _ map_scope].
 
 (** All projections should be made opaque for tactics using [delta]-conversion,
    otherwise the underlying instances may appear during proofs, which then

--- a/theories/MapList.v
+++ b/theories/MapList.v
@@ -1306,9 +1306,9 @@ Section MapDefinitions.
 
   Let t elt := dict key elt.
 
-  Implicit Types m : t elt.
+  Implicit Type m : t elt.
   Implicit Types x y : key.
-  Implicit Types e : elt.
+  Implicit Type e : elt.
 
   Definition empty : t elt := Build_dict (M.empty_sorted elt).
   Definition is_empty m : bool := M.is_empty m.(this).

--- a/theories/MapList.v
+++ b/theories/MapList.v
@@ -178,37 +178,22 @@ Section MapDefinitions.
     end.
 End MapDefinitions.
 
-Implicit Arguments Empty [[key] [elt] [comparedec]].
-Implicit Arguments
-  empty [[key] [elt] [comparedec]].
-Implicit Arguments
-  is_empty [[key] [elt] [comparedec]].
-Implicit Arguments
-  mem [[key] [elt] [comparedec]].
-Implicit Arguments
-  find [[key] [elt] [comparedec]].
-Implicit Arguments
-  add [[key] [elt] [comparedec]].
-Implicit Arguments
-  remove [[key] [elt] [comparedec]].
-Implicit Arguments
-  insert [[key] [elt] [comparedec]].
-Implicit Arguments
-  adjust [[key] [elt] [comparedec]].
-Implicit Arguments
-  equal [[key] [elt] [comparedec]].
-Implicit Arguments
-  fold [[key] [comparedec] [elt] [A]].
-Implicit Arguments
-  elements [[key] [elt] [comparedec]].
-Implicit Arguments
-  choose [[key] [elt] [comparedec]].
-Implicit Arguments
-  map [[key] [elt] [elt'] [comparedec]].
-Implicit Arguments
-  mapi [[key] [elt] [elt'] [comparedec]].
-Implicit Arguments
-  map2 [[key] [elt] [elt'] [elt''] [comparedec]].
+Arguments Empty {key comparedec elt}.
+Arguments empty {key comparedec elt}.
+Arguments is_empty {key comparedec elt}.
+Arguments mem {key comparedec elt}.
+Arguments find {key comparedec elt}.
+Arguments add {key comparedec elt}.
+Arguments remove {key comparedec elt}.
+Arguments insert {key comparedec elt}.
+Arguments adjust {key comparedec elt}.
+Arguments equal {key comparedec elt}.
+Arguments fold {key comparedec elt A}.
+Arguments elements {key comparedec elt}.
+Arguments choose {key comparedec elt}.
+Arguments map {key comparedec elt elt'}.
+Arguments mapi {key comparedec elt elt'}.
+Arguments map2 {key comparedec elt elt' elt''}.
 
 (** Maps seen as an OrderedType : list comparison based
    solely on the first component. *)
@@ -1310,9 +1295,9 @@ Structure dict (key : Type) `{OrderedType key} (elt : Type) := Build_dict {
   this :> M.dict key elt;
   sorted : sort (M.K.ltk (elt:=elt)) this
 }.
-Implicit Arguments this [[key] [elt] [H]].
-Implicit Arguments Build_dict [[key] [elt] [H] [this]].
-Implicit Arguments sorted [[key] [elt] [H]].
+Arguments this {key H elt}.
+Arguments Build_dict {key H elt this}.
+Arguments sorted {key H elt}.
 
 Section MapDefinitions.
   Variable key : Type.

--- a/theories/MapPositive.v
+++ b/theories/MapPositive.v
@@ -88,7 +88,7 @@ Module PositiveMap.
   Section A.
   Variable A:Type.
 
-  Implicit Arguments Leaf [A].
+  Arguments Leaf {A}.
 
   Definition empty : t A := Leaf.
 
@@ -952,7 +952,7 @@ Module PositiveMap.
   Variable A B C : Type.
   Variable f : option A -> option B -> option C.
 
-  Implicit Arguments Leaf [A].
+  Arguments Leaf {A}.
 
   Fixpoint xmap2_l (m : t A) {struct m} : t C :=
       match m with

--- a/theories/OrderedType.v
+++ b/theories/OrderedType.v
@@ -1,4 +1,5 @@
 Require Import Setoid Morphisms.
+Require SetoidList.
 Require Export Coq.Classes.Equivalence.
 Open Scope equiv_scope.
 
@@ -478,7 +479,7 @@ Notation "'UsualOrderedType' A" :=
    *)
 Set Implicit Arguments. Unset Strict Implicit.
 Section ForNotations.
-  Require Import SetoidList.
+  Import SetoidList.
   Notation In:=(InA _eq).
   Notation Inf:=(lelistA _lt).
   Notation Sort:=(sort _lt).
@@ -533,6 +534,7 @@ Hint Immediate @In_eq @Inf_lt.
 
 Module KeyOrderedType.
 Section KeyOrderedType.
+  Import SetoidList.
   Set Implicit Arguments.
   Unset Strict Implicit.
 

--- a/theories/OrderedType.v
+++ b/theories/OrderedType.v
@@ -765,9 +765,9 @@ Hint Resolve Inf_lt.
 Hint Resolve Sort_Inf_NotIn.
 Hint Resolve In_inv_2 In_inv_3.
 
-Implicit Arguments eqk [[key] [elt] [key_OT]].
-Implicit Arguments eqke [[key] [elt] [key_OT]].
-Implicit Arguments ltk [[key] [elt] [key_OT]].
-Implicit Arguments MapsTo [[key] [elt] [key_OT]].
-Implicit Arguments In [[key] [elt] [key_OT]].
+Arguments eqk {key key_OT elt}.
+Arguments eqke {key key_OT elt}.
+Arguments ltk {key key_OT elt}.
+Arguments MapsTo {key key_OT elt}.
+Arguments In {key key_OT elt}.
 End KeyOrderedType.

--- a/theories/OrderedTypeEx.v
+++ b/theories/OrderedTypeEx.v
@@ -12,20 +12,20 @@ Require Export Tactics.
 
 (** ** [Z] *)
 Require Import ZArith.
-Instance Z_StrictOrder : StrictOrder Zlt (@eq Z) := {
-  StrictOrder_Transitive := Zlt_trans;
+Instance Z_StrictOrder : StrictOrder Z.lt (@eq Z) := {
+  StrictOrder_Transitive := Z.lt_trans;
   StrictOrder_Irreflexive := Zlt_not_eq
 }.
 Program Instance Z_OrderedType : UsualOrderedType Z := {
-  SOT_lt := Zlt;
-  SOT_cmp := Zcompare;
+  SOT_lt := Z.lt;
+  SOT_cmp := Z.compare;
   SOT_StrictOrder := Z_StrictOrder
 }.
 Next Obligation.
-  case_eq (Zcompare x y); intro Hcomp; constructor.
+  case_eq (Z.compare x y); intro Hcomp; constructor.
   apply Zcompare_Eq_eq; assumption.
   assumption.
-  apply Zgt_lt; assumption.
+  apply Z.gt_lt; assumption.
 Qed.
 
 (** ** [nat] *)
@@ -85,30 +85,30 @@ Proof.
 Qed.
 Program Instance N_OrderedType : UsualOrderedType N := {
   SOT_lt := fun p q => Nleb q p = false;
-  SOT_cmp := Ncompare;
+  SOT_cmp := N.compare;
   SOT_StrictOrder := N_StrictOrder
 }.
 Next Obligation.
-  case_eq (Ncompare x y); intro Hcomp; constructor.
+  case_eq (N.compare x y); intro Hcomp; constructor.
   apply Ncompare_Eq_eq; assumption.
   assert (H := Nleb_Nle y x); destruct (Nleb y x); auto.
-  assert (H' := (proj1 H) (refl_equal _)); unfold Nle in H'.
+  assert (H' := (proj1 H) (refl_equal _)); unfold N.le in H'.
   rewrite <- Ncompare_antisym in H'; rewrite Hcomp in H';
     contradiction H'; auto.
   assert (H := Nleb_Nle x y); destruct (Nleb x y); auto.
-  assert (H' := (proj1 H) (refl_equal _)); unfold Nle in H'.
+  assert (H' := (proj1 H) (refl_equal _)); unfold N.le in H'.
   congruence.
 Qed.
 
 (** ** [positive] *)
-Instance positive_StrictOrder : StrictOrder Plt (@eq positive) := {
-  StrictOrder_Transitive := Plt_trans
+Instance positive_StrictOrder : StrictOrder Pos.lt (@eq positive) := {
+  StrictOrder_Transitive := Pos.lt_trans
 }.
 Proof.
-  intros x y H abs; rewrite abs in H; exact (Plt_irrefl y H).
+  intros x y H abs; rewrite abs in H; exact (Pos.lt_irrefl y H).
 Qed.
 Program Instance positive_OrderedType : UsualOrderedType positive := {
-  SOT_lt := Plt;
+  SOT_lt := Pos.lt;
   SOT_cmp := fun p q => Pcompare p q Eq;
   SOT_StrictOrder := positive_StrictOrder
 }.

--- a/theories/SetAVL.v
+++ b/theories/SetAVL.v
@@ -89,7 +89,7 @@ Module SetAVL.
 
     (** [create l x r] creates a node, assuming [l] and [r]
        to be balanced and [|height l - height r| <= 2]. *)
-    Notation max := Zmax.
+    Notation max := Z.max.
     Definition create l x r :=
       Node l x r (max (height l) (height r) + 1).
 

--- a/theories/SetAVL.v
+++ b/theories/SetAVL.v
@@ -383,7 +383,7 @@ Module SetAVL.
                  | Leaf => a
                  | Node l x r _ => fold f r (f x (fold f l a))
                end.
-    Implicit Arguments fold [A].
+    Arguments fold [A].
 
     (** * Subset *)
 
@@ -1554,7 +1554,7 @@ Module SetAVL.
     Import Bool.
     Definition fold' (A : Type) (f : elt -> A -> A)(s : tree) :=
       SetList.SetList.fold f (elements s).
-    Implicit Arguments fold' [A].
+    Arguments fold' [A].
 
     Lemma fold_equiv_aux :
       forall (A : Type) (s : tree) (f : elt -> A -> A) (a : A) (acc : list elt),
@@ -1884,9 +1884,9 @@ Module S := SetAVL.
 
 Structure set (elt : Type) `{Helt : OrderedType elt}
   := Bst {this :> @S.tree elt Helt; is_bst : S.bst this}.
-Implicit Arguments this [[elt] [Helt]].
-Implicit Arguments Bst [[elt] [Helt] [this]].
-Implicit Arguments is_bst [[elt] [Helt]].
+Arguments this {elt Helt}.
+Arguments Bst {elt Helt this}.
+Arguments is_bst {elt Helt}.
 
 Section SetDefinitions.
   Context `{Helt : OrderedType elt}.

--- a/theories/SetAVL.v
+++ b/theories/SetAVL.v
@@ -700,8 +700,8 @@ Module SetAVL.
 (*     Functional Scheme diff_ind := Induction for diff Sort Prop. *)
 (*     Functional Scheme union_ind := Induction for union Sort Prop. *)
 
-    Implicit Types x : elt.
-    Implicit Types s : tree (elt:=elt).
+    Implicit Type x : elt.
+    Implicit Type s : tree (elt:=elt).
 
     (** * Empty set *)
 

--- a/theories/SetConstructs.v
+++ b/theories/SetConstructs.v
@@ -1,3 +1,4 @@
+Require Recdef.
 Require Import SetInterface SetAVLInstance.
 Require Import SetFacts SetProperties.
 
@@ -248,7 +249,6 @@ Section DiagonalProduct.
 
   (* diag {} = {};
      diag {x; s} = diag s \cup {(x, a) | a \in s} si x < s *)
-  Require Import Recdef.
   Function diag_prod (s : set A) {measure cardinal} : set (A * A) :=
       match min_elt s with
         | None => {}

--- a/theories/SetEqProperties.v
+++ b/theories/SetEqProperties.v
@@ -468,7 +468,7 @@ Section Fold.
   Context {Comp : Proper (_eq ==> eqA ==> eqA) f}.
   Hypothesis Ass :transpose eqA f.
 
-  Variables (i:A).
+  Variable (i:A).
   Variables (s s':set elt)(x:elt).
 
   Lemma fold_empty : (fold f empty i) = i.

--- a/theories/SetInterface.v
+++ b/theories/SetInterface.v
@@ -89,7 +89,7 @@ Class FSet `{OrderedType A} := {
     SpecificOrderedType _ (Equal_pw set A In)
 }.
 
-Implicit Arguments set [[H] [FSet]].
+Arguments set _ {H FSet}.
 
 (** Set notations (see below) are interpreted in scope [set_scope],
    delimited with key [scope]. We bind it to the type [set] and to

--- a/theories/SetInterface.v
+++ b/theories/SetInterface.v
@@ -92,30 +92,9 @@ Class FSet `{OrderedType A} := {
 Arguments set _ {H FSet}.
 
 (** Set notations (see below) are interpreted in scope [set_scope],
-   delimited with key [scope]. We bind it to the type [set] and to
-   other operations defined in the interface. *)
+   delimited with key [set]. We bind it to the type [set]. *)
 Delimit Scope set_scope with set.
 Bind Scope set_scope with set.
-Arguments Scope In [type_scope _ _ _ set_scope].
-Arguments Scope is_empty [type_scope _ _ set_scope].
-Arguments Scope mem [type_scope _ _ _ set_scope].
-Arguments Scope add [type_scope _ _ _ set_scope].
-Arguments Scope remove [type_scope _ _ _ set_scope].
-Arguments Scope union [type_scope _ _ set_scope set_scope].
-Arguments Scope inter [type_scope _ _ set_scope set_scope].
-Arguments Scope diff [type_scope _ _ set_scope set_scope].
-Arguments Scope equal [type_scope _ _ set_scope set_scope].
-Arguments Scope subset [type_scope _ _ set_scope set_scope].
-Arguments Scope fold [type_scope _ _ _ _ set_scope _].
-Arguments Scope for_all [type_scope _ _ _ set_scope].
-Arguments Scope exists_ [type_scope _ _ _ set_scope].
-Arguments Scope filter [type_scope _ _ _ set_scope].
-Arguments Scope partition [type_scope _ _ _ set_scope].
-Arguments Scope cardinal [type_scope _ _ set_scope].
-Arguments Scope elements [type_scope _ _ set_scope].
-Arguments Scope choose [type_scope _ _ set_scope].
-Arguments Scope min_elt [type_scope _ _ set_scope].
-Arguments Scope max_elt [type_scope _ _ set_scope].
 
 (** All projections should be made opaque for tactics using [delta]-conversion,
    otherwise the underlying instances may appear during proofs, which then

--- a/theories/SetList.v
+++ b/theories/SetList.v
@@ -194,38 +194,38 @@ Module SetList.
     Definition Exists (P : elt -> Prop) (s : t) := exists x, In x s /\ P x.
   End SetDefinitions.
 
-  Implicit Arguments empty [[elt] [comparedec]].
-  Implicit Arguments is_empty [[elt] [comparedec]].
-  Implicit Arguments mem [[elt] [comparedec]].
-  Implicit Arguments add [[elt] [comparedec]].
-  Implicit Arguments singleton [[elt] [comparedec]].
-  Implicit Arguments remove [[elt] [comparedec]].
-  Implicit Arguments union [[elt] [comparedec]].
-  Implicit Arguments inter [[elt] [comparedec]].
-  Implicit Arguments diff [[elt] [comparedec]].
-  Implicit Arguments equal [[elt] [comparedec]].
-  Implicit Arguments subset [[elt] [comparedec]].
-  Implicit Arguments map_monotonic [[elt] [comparedec] [B] [H]].
-  Implicit Arguments fold [[elt] [comparedec] [B]].
-  Implicit Arguments filter [[elt] [comparedec]].
-  Implicit Arguments for_all [[elt] [comparedec]].
-  Implicit Arguments exists_ [[elt] [comparedec]].
-  Implicit Arguments partition [[elt] [comparedec]].
-  Implicit Arguments cardinal [[elt] [comparedec]].
-  Implicit Arguments elements [[elt] [comparedec]].
-  Implicit Arguments min_elt [[elt] [comparedec]].
-  Implicit Arguments max_elt [[elt] [comparedec]].
-  Implicit Arguments choose [[elt] [comparedec]].
-  Implicit Arguments Equal [[elt] [comparedec]].
-  Implicit Arguments Subset [[elt] [comparedec]].
-  Implicit Arguments Empty [[elt] [comparedec]].
-  Implicit Arguments For_all [[elt] [comparedec]].
-  Implicit Arguments Exists [[elt] [comparedec]].
+  Arguments empty {elt comparedec}.
+  Arguments is_empty {elt comparedec}.
+  Arguments mem {elt comparedec}.
+  Arguments add {elt comparedec}.
+  Arguments singleton {elt comparedec}.
+  Arguments remove {elt comparedec}.
+  Arguments union {elt comparedec}.
+  Arguments inter {elt comparedec}.
+  Arguments diff {elt comparedec}.
+  Arguments equal {elt comparedec}.
+  Arguments subset {elt comparedec}.
+  Arguments map_monotonic {elt comparedec B H}.
+  Arguments fold {elt comparedec B}.
+  Arguments filter {elt comparedec}.
+  Arguments for_all {elt comparedec}.
+  Arguments exists_ {elt comparedec}.
+  Arguments partition {elt comparedec}.
+  Arguments cardinal {elt comparedec}.
+  Arguments elements {elt comparedec}.
+  Arguments min_elt {elt comparedec}.
+  Arguments max_elt {elt comparedec}.
+  Arguments choose {elt comparedec}.
+  Arguments Equal {elt comparedec}.
+  Arguments Subset {elt comparedec}.
+  Arguments Empty {elt comparedec}.
+  Arguments For_all {elt comparedec}.
+  Arguments Exists {elt comparedec}.
 
   Definition map {A : Type} `{OrderedType A} {B : Type} `{OrderedType B}
     (f : A -> B) (s : set A) : set B :=
       fold (fun a sb => add (f a) sb) s empty.
-  Implicit Arguments map [[A] [H] [B] [H0]].
+  Arguments map {A H B H0}.
 
   (** Sets seen as a CompareDec (uses list_CompareDec, but in an opaque way) *)
   Definition set_eq `{OrderedType A} : relation (set A) := @list_eq A _eq.
@@ -1100,9 +1100,9 @@ Module S := SetList.
 
 Structure set (A : Type) `{OrderedType A}
   := Build_set {this :> list A; sorted : sort _lt this}.
-Implicit Arguments this [[A] [H]].
-Implicit Arguments Build_set [[A] [H] [this]].
-Implicit Arguments sorted [[A] [H]].
+Arguments this {A H}.
+Arguments Build_set {A H this}.
+Arguments sorted {A H}.
 
 Section SetDefinitions.
   Variable A : Type.
@@ -1155,28 +1155,28 @@ Section SetDefinitions.
   Definition choose := min_elt.
 End SetDefinitions.
 
-Implicit Arguments empty [[A] [comparedec]].
-Implicit Arguments is_empty [[A] [comparedec]].
-Implicit Arguments mem [[A] [comparedec]].
-Implicit Arguments add [[A] [comparedec]].
-Implicit Arguments singleton [[A] [comparedec]].
-Implicit Arguments remove [[A] [comparedec]].
-Implicit Arguments union [[A] [comparedec]].
-Implicit Arguments inter [[A] [comparedec]].
-Implicit Arguments diff [[A] [comparedec]].
-Implicit Arguments equal [[A] [comparedec]].
-Implicit Arguments subset [[A] [comparedec]].
-Implicit Arguments map_monotonic [[A] [comparedec] [B] [H] [Mono]].
-Implicit Arguments fold [[A] [comparedec] [B]].
-Implicit Arguments filter [[A] [comparedec]].
-Implicit Arguments for_all [[A] [comparedec]].
-Implicit Arguments exists_ [[A] [comparedec]].
-Implicit Arguments partition [[A] [comparedec]].
-Implicit Arguments cardinal [[A] [comparedec]].
-Implicit Arguments elements [[A] [comparedec]].
-Implicit Arguments min_elt [[A] [comparedec]].
-Implicit Arguments max_elt [[A] [comparedec]].
-Implicit Arguments choose [[A] [comparedec]].
+Arguments empty {A comparedec}.
+Arguments is_empty {A comparedec}.
+Arguments mem {A comparedec}.
+Arguments add {A comparedec}.
+Arguments singleton {A comparedec}.
+Arguments remove {A comparedec}.
+Arguments union {A comparedec}.
+Arguments inter {A comparedec}.
+Arguments diff {A comparedec}.
+Arguments equal {A comparedec}.
+Arguments subset {A comparedec}.
+Arguments map_monotonic {A comparedec B H} _ {Mono}.
+Arguments fold {A comparedec B}.
+Arguments filter {A comparedec}.
+Arguments for_all {A comparedec}.
+Arguments exists_ {A comparedec}.
+Arguments partition {A comparedec}.
+Arguments cardinal {A comparedec}.
+Arguments elements {A comparedec}.
+Arguments min_elt {A comparedec}.
+Arguments max_elt {A comparedec}.
+Arguments choose {A comparedec}.
 
 Set Implicit Arguments.
 Unset Strict Implicit.


### PR DESCRIPTION
Concerning “Arguments Scope”, I just removed the commands as the default (automatically inferred) scopes looked better (more precise) that the ones given explicitly.